### PR TITLE
SN-1268 adding map_with_context functionality

### DIFF
--- a/base_stream.go
+++ b/base_stream.go
@@ -19,6 +19,11 @@ func (this *baseStream) Map(fn MapFunc) Stream {
 	return this
 }
 
+func (this *baseStream) MapWithContext(mapWithContext MapWithContext) Stream {
+	this.ops = append(this.ops, mapWithContext)
+	return this
+}
+
 func (this *baseStream) Sink(sink Sink) Stream {
 	this.ops = append(this.ops, sink)
 	return this

--- a/buffered_processor.go
+++ b/buffered_processor.go
@@ -89,6 +89,15 @@ func (this *bufferedProcessor) processBuffer(source Source, entries []Entry, key
 				entries[idx].Value = RecoverMap(handler, entries[idx], errs)
 			}
 
+		case MapWithContext:
+			context := handler.GetContextFunc()
+			for idx := range entries {
+				if entries[idx].Filtered {
+					continue
+				}
+				entries[idx].Value = RecoverMapWithContext(context, handler.MapWithContextFunc, entries[idx], errs)
+			}
+
 		case Sink:
 			arr := make([]Entry, len(entries)-filteredCount)
 			arrIdx := 0

--- a/direct_processor.go
+++ b/direct_processor.go
@@ -42,6 +42,10 @@ EntryLoop:
 			case MapFunc:
 				entry.Value = RecoverMap(handler, entry, errs)
 
+			case MapWithContext:
+				context := handler.GetContextFunc()
+				entry.Value = RecoverMapWithContext(context, handler.MapWithContextFunc, entry, errs)
+
 			case Sink:
 				if err := RecoverSinkSingle(handler, entry, errs); err != nil {
 					errs <- err

--- a/manifest.go
+++ b/manifest.go
@@ -1,5 +1,7 @@
 package go_streams
 
+import "context"
+
 // Entry is the data model that go-streams passes between
 // different operators although the user never handle it directly
 // when creating new streams.
@@ -24,6 +26,18 @@ type KeyExtractor func(entry Entry) string
 // MapFunc is a function which transforms its input
 type MapFunc func(entry interface{}) interface{}
 
+// Like the MapFunc, but enables the function to be called with a context for more complex transformations
+type MapWithContext struct {
+	GetContextFunc     GetContextFunc
+	MapWithContextFunc MapWithContextFunc
+}
+
+// Map function that also get a context parameter
+type MapWithContextFunc func(context context.Context, entry interface{}) interface{}
+
+// A function that will pass context to the MapWithContextFunc
+type GetContextFunc func() context.Context
+
 // FilterFunc is a function that takes an entry an decided
 // if this entry should be filtered out
 // return true to keep the record or false to filter it out.
@@ -47,6 +61,9 @@ type Stream interface {
 
 	// Map entries
 	Map(fn MapFunc) Stream
+
+	//
+	MapWithContext(mapWithContext MapWithContext) Stream
 
 	// Sink (or dump) the stream entries to this Sink implementation
 	// such as file, database, memory, etc...

--- a/manifest.go
+++ b/manifest.go
@@ -1,7 +1,5 @@
 package go_streams
 
-import "context"
-
 // Entry is the data model that go-streams passes between
 // different operators although the user never handle it directly
 // when creating new streams.
@@ -33,10 +31,10 @@ type MapWithContext struct {
 }
 
 // Map function that also get a context parameter
-type MapWithContextFunc func(context context.Context, entry interface{}) interface{}
+type MapWithContextFunc func(context map[string]interface{}, entry interface{}) interface{}
 
 // A function that will pass context to the MapWithContextFunc
-type GetContextFunc func() context.Context
+type GetContextFunc func() map[string]interface{}
 
 // FilterFunc is a function that takes an entry an decided
 // if this entry should be filtered out

--- a/map_with_context_test.go
+++ b/map_with_context_test.go
@@ -1,7 +1,6 @@
 package go_streams
 
 import (
-	"context"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -56,13 +55,14 @@ func appendNumbers(source *AppendSource) {
 }
 
 func getMapFunc() MapWithContext {
-	ctx := context.WithValue(context.Background(), "addNum", 10)
+	ctx := make(map[string]interface{})
+	ctx["addNum"] = 10
 	return MapWithContext{
-		GetContextFunc: func() context.Context {
+		GetContextFunc: func() map[string]interface{} {
 			return ctx
 		},
-		MapWithContextFunc: func(context context.Context, entry interface{}) interface{} {
-			addNum := context.Value("addNum").(int)
+		MapWithContextFunc: func(context map[string]interface{}, entry interface{}) interface{} {
+			addNum := context["addNum"].(int)
 			num := entry.(int)
 			return num + addNum
 		},

--- a/map_with_context_test.go
+++ b/map_with_context_test.go
@@ -1,0 +1,70 @@
+package go_streams
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestMapWithContext_Buffered(t *testing.T) {
+	source, array, errs := createStreamResources()
+	processor := NewBufferedProcessor(5, 256*time.Millisecond)
+
+	stream := NewStream(source).
+		MapWithContext(getMapFunc()).
+		Sink(array)
+	go stream.Process(processor, errs)
+
+	appendNumbers(source)
+	assertResults(t, source, array)
+}
+
+func TestMapWithContext_Direct(t *testing.T) {
+	source, array, errs := createStreamResources()
+	processor := NewDirectProcessor()
+
+	stream := NewStream(source).
+		MapWithContext(getMapFunc()).
+		Sink(array)
+	go stream.Process(processor, errs)
+
+	appendNumbers(source)
+	assertResults(t, source, array)
+}
+
+func createStreamResources() (*AppendSource, *ArraySink, ErrorChannel) {
+	source := NewAppendSource(5)
+	array := NewArraySink()
+	errs := make(ErrorChannel, 5)
+	return source, array, errs
+}
+
+func assertResults(t *testing.T, source *AppendSource, array *ArraySink) {
+	time.Sleep(time.Second)
+	assert.NoError(t, source.Stop())
+	expected := []interface{}{11, 12, 13, 14, 15}
+	assert.Equal(t, expected, array.Array())
+}
+
+func appendNumbers(source *AppendSource) {
+	source.Append("1", 1)
+	source.Append("2", 2)
+	source.Append("3", 3)
+	source.Append("4", 4)
+	source.Append("5", 5)
+}
+
+func getMapFunc() MapWithContext {
+	ctx := context.WithValue(context.Background(), "addNum", 10)
+	return MapWithContext{
+		GetContextFunc: func() context.Context {
+			return ctx
+		},
+		MapWithContextFunc: func(context context.Context, entry interface{}) interface{} {
+			addNum := context.Value("addNum").(int)
+			num := entry.(int)
+			return num + addNum
+		},
+	}
+}

--- a/recovery.go
+++ b/recovery.go
@@ -1,7 +1,6 @@
 package go_streams
 
 import (
-	"context"
 	"fmt"
 )
 
@@ -37,7 +36,7 @@ func RecoverMap(mapFunc MapFunc, entry Entry, errs ErrorChannel) interface{} {
 	return mapFunc(entry.Value)
 }
 
-func RecoverMapWithContext(context context.Context, mapFunc MapWithContextFunc, entry Entry, errs ErrorChannel) interface{} {
+func RecoverMapWithContext(context map[string]interface{}, mapFunc MapWithContextFunc, entry Entry, errs ErrorChannel) interface{} {
 	defer func() {
 		if p := recover(); p != nil {
 			logger.Debug("Recovering from panic in mapWithContext step for entry: %+v", entry)


### PR DESCRIPTION
Added a map_with_context functionality to the processor.
The idea is that sometimes I want the MapFunc to do transformations using some other information that is constantly changing and not static.
There are two functions sent in this MapWithContext struct, one is a GetContext that will provide the context an the other is a MapFunc that receives this context and can use it.

My use case is that I have a cache object (thread safe) an I want that the BatchProcessor will make a copy of the cache state every time it needs to process a batch, so each event processing is working on that copy but the copy is done once in the GetContext function that is passed.

Note that concurrency needs to be handled outside of the lib, in the functions passed and the objects used.